### PR TITLE
Undefined variables in diffusion ditherer

### DIFF
--- a/lib/algorithms/errorDiffusionDither.js
+++ b/lib/algorithms/errorDiffusionDither.js
@@ -7,7 +7,7 @@ function errorDiffusionDither(uint8data, palette, step, h, w) {
         return (4*x) + (4*y*w);
     };
 
-    var r, g, b, a, q, i, color, approx, tr, tg, tb, dx, dy, di;
+    var r, g, b, a, q, x, y, i, color, approx, tr, tg, tb, dx, dy, di;
 
     for (y=0;y<h;y += step) {
         for (x=0;x<w;x += step) {


### PR DESCRIPTION
The `x` and `y` variables used in `errorDiffusionDither` are never declared in the function, which causes a ReferenceError in strict mode. Not sure if this repo is maintained, but I'll give it a shot anyway!